### PR TITLE
Added exception and soapFault

### DIFF
--- a/example-file/Step17-text
+++ b/example-file/Step17-text
@@ -1,0 +1,24 @@
+//### Section - 5 | Step 17: Exception Handling and SOAP Fault Responses
+
+When there is an error, we need to send something called a fault response. A SOAP envelope defines a header and a body. Until
+now we sent a proper request/response as part of our body. The other thing which can be present in the body is also a fault
+response. When do you send a fault response? When there is an exception that happens.
+
+For eg, in the operation GetCourseDetailById, if we enter an invalid Id, we will get a Null Pointer Exception. We can notice
+that whenever there is this exception that happens, there is a proper response already coming back. It's not going to a 404
+page or I'm not sending an empty response or something of that kind. What is happening here is a proper envelope with a header
+and the body and the fault is getting created and an error response is being sent back. So, there is proper exception handling
+which is already defined which returns a fault code and the fault string.
+
+What we can do is, instead of using Runtime Exception we can create a course not found exception.
+To specify it it's actually a client's fault or server fault, we can use - @SoapFault(faultCode = FaultCode.CLIENT) annotation.
+We can also define custom SoapFault using - @SoapFault(FaultCode = FaultCode.CUSTOM, customFaultCode="{namespace}custom-fault-name")
+for eg - @SoapFault(FaultCode = FaultCode.CUSTOM, customFaultCode="{http://in28minutes.com/courses}001_COURSE_NOT_FOUND")
+
+
+
+
+
+
+
+

--- a/src/main/java/com/nichoudhary/soap/webservices/soapcoursemanagement/soap/CourseDetailsEndpoint.java
+++ b/src/main/java/com/nichoudhary/soap/webservices/soapcoursemanagement/soap/CourseDetailsEndpoint.java
@@ -7,6 +7,7 @@ import com.in28minutes.courses.GetAllCourseDetailsRequest;
 import com.in28minutes.courses.GetAllCourseDetailsResponse;
 import com.in28minutes.courses.GetCourseDetailsRequest;
 import com.in28minutes.courses.GetCourseDetailsResponse;
+import com.nichoudhary.soap.webservices.soapcoursemanagement.soap.exception.CourseNotFoundException;
 import com.nichoudhary.soap.webservices.soapcoursemanagement.soap.service.CourseDetailsService.Status;
 import com.nichoudhary.soap.webservices.soapcoursemanagement.soap.bean.Course;
 import com.nichoudhary.soap.webservices.soapcoursemanagement.soap.service.CourseDetailsService;
@@ -36,6 +37,10 @@ public class CourseDetailsEndpoint {
     public GetCourseDetailsResponse processCourseDetailsRequest(@RequestPayload GetCourseDetailsRequest request) {
 
         Course course = service.findById(request.getId());
+        /*if(course == null)
+            throw new RuntimeException("Invalid Course " + request.getId());*/
+        if(course == null)
+            throw new CourseNotFoundException("Invalid Course " + request.getId());
         return mapCourseDetails(course);
     }
 

--- a/src/main/java/com/nichoudhary/soap/webservices/soapcoursemanagement/soap/exception/CourseNotFoundException.java
+++ b/src/main/java/com/nichoudhary/soap/webservices/soapcoursemanagement/soap/exception/CourseNotFoundException.java
@@ -1,0 +1,13 @@
+package com.nichoudhary.soap.webservices.soapcoursemanagement.soap.exception;
+
+import org.springframework.ws.soap.server.endpoint.annotation.FaultCode;
+import org.springframework.ws.soap.server.endpoint.annotation.SoapFault;
+
+@SoapFault(faultCode = FaultCode.CLIENT)
+public class CourseNotFoundException extends RuntimeException{
+
+    //private static final long serialVersionUID = 3518170101751491969L;
+    public CourseNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
//### Section - 5 | Step 17: Exception Handling and SOAP Fault Responses

When there is an error, we need to send something called a fault response. A SOAP envelope defines a header and a body. Until
now we sent a proper request/response as part of our body. The other thing which can be present in the body is also a fault
response. When do you send a fault response? When there is an exception that happens.

For eg, in the operation GetCourseDetailById, if we enter an invalid Id, we will get a Null Pointer Exception. We can notice
that whenever there is this exception that happens, there is a proper response already coming back. It's not going to a 404
page or I'm not sending an empty response or something of that kind. What is happening here is a proper envelope with a header
and the body and the fault is getting created and an error response is being sent back. So, there is proper exception handling
which is already defined which returns a fault code and the fault string.

What we can do is, instead of using Runtime Exception we can create a course not found exception.
To specify it it's actually a client's fault or server fault, we can use - @SoapFault(faultCode = FaultCode.CLIENT) annotation.
We can also define custom SoapFault using - @SoapFault(FaultCode = FaultCode.CUSTOM, customFaultCode="{namespace}custom-fault-name")
for eg - @SoapFault(FaultCode = FaultCode.CUSTOM, customFaultCode="{http://in28minutes.com/courses}001_COURSE_NOT_FOUND")

